### PR TITLE
Support 'newStyle' @cspell dicts + add norwegian

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Dictionaries:
 - german `de`
 - greek `el`
 - italian `it`
+- norwegian `nb, nb-no`
 - persian `fa`
 - polish `pl`
 - portuguese `pt,pt_PT`

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.2",
   "publisher": "iamcco",
   "engines": {
-    "coc": "^0.0.74"
+    "coc": "^0.0.80"
   },
   "keywords": [
     "coc.nvim",
@@ -41,6 +41,7 @@
               "greek",
               "italian",
               "medical-terms",
+              "norwegian",
               "persian",
               "polish",
               "portuguese",
@@ -74,6 +75,7 @@
     "prepublishOnly": "npm run clean && npm run build"
   },
   "dependencies": {
+    "@cspell/dict-nb-no": "^1.0.3",
     "cspell-dict-ca": "^1.0.9",
     "cspell-dict-cs-cz": "^1.0.9",
     "cspell-dict-da-dk": "^1.0.16",
@@ -96,8 +98,8 @@
     "cspell-dict-uk-ua": "^1.0.9"
   },
   "devDependencies": {
-    "@types/node": "^13.1.2",
-    "coc.nvim": "^0.0.74",
-    "vscode-languageserver-protocol": "^3.14.1"
+    "@types/node": "12.12.12",
+    "coc.nvim": "^0.0.80",
+    "typescript": "^4.5.4"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,83 +5,89 @@ const dicts: Record<
   {
     local?: string;
     package: string | string[];
+    newStyle?: boolean;
   }
 > = {
   catalan: {
     local: "ca",
-    package: "cspell-dict-ca"
+    package: "cspell-dict-ca",
   },
   czech: {
     local: "cs",
-    package: "cspell-dict-cs-cz"
+    package: "cspell-dict-cs-cz",
+  },
+  norwegian: {
+    newStyle: true,
+    local: "nb, nb-no",
+    package: "@cspell/dict-nb-no",
   },
   danish: {
     local: "dk",
-    package: "cspell-dict-da-dk"
+    package: "cspell-dict-da-dk",
   },
   dutch: {
     local: "nl",
-    package: "cspell-dict-nl-nl"
+    package: "cspell-dict-nl-nl",
   },
   french: {
     local: "fr",
-    package: "cspell-dict-fr-fr"
+    package: "cspell-dict-fr-fr",
   },
   "french-reforme": {
     local: "fr-90",
-    package: "cspell-dict-fr-reforme"
+    package: "cspell-dict-fr-reforme",
   },
   german: {
     local: "de",
-    package: "cspell-dict-de-de"
+    package: "cspell-dict-de-de",
   },
   greek: {
     local: "el",
-    package: "cspell-dict-el"
+    package: "cspell-dict-el",
   },
   italian: {
     local: "it",
-    package: "cspell-dict-it-it"
+    package: "cspell-dict-it-it",
   },
   "medical-terms": {
-    package: "cspell-dict-medicalterms"
+    package: "cspell-dict-medicalterms",
   },
   persian: {
     local: "fa",
-    package: "cspell-dict-fa-ir"
+    package: "cspell-dict-fa-ir",
   },
   polish: {
     local: "pl",
-    package: "cspell-dict-pl_pl"
+    package: "cspell-dict-pl_pl",
   },
   portuguese: {
     local: "pt,pt_PT",
-    package: "cspell-dict-pt-pt"
+    package: "cspell-dict-pt-pt",
   },
   "portuguese-brazilian": {
     local: "pt,pt_BR",
-    package: "cspell-dict-pt-br"
+    package: "cspell-dict-pt-br",
   },
   russian: {
     local: "ru",
-    package: ["cspell-dict-ru_ru", "cspell-dict-russian"]
+    package: ["cspell-dict-ru_ru", "cspell-dict-russian"],
   },
   spanish: {
     local: "es",
-    package: "cspell-dict-es-es"
+    package: "cspell-dict-es-es",
   },
   swedish: {
     local: "sv",
-    package: "cspell-dict-sv"
+    package: "cspell-dict-sv",
   },
   turkish: {
     local: "tr",
-    package: "cspell-dict-tr-tr"
+    package: "cspell-dict-tr-tr",
   },
   ukrainian: {
     local: "uk",
-    package: "cspell-dict-uk-ua"
-  }
+    package: "cspell-dict-uk-ua",
+  },
 };
 
 // this method is called when your extension is activated
@@ -93,42 +99,56 @@ export function activate(context: coc.ExtensionContext) {
     .getConfiguration("cSpellExt")
     .get<string[]>("enableDictionaries", []);
 
-  const cocSpellChecker = coc.extensions.getExtension(cocSpellCheckerExtension)
+  // const cocSpellChecker = coc.extensions.getExtension(cocSpellCheckerExtension);
+  // hack: getExtension() is not defined in coc.nvim 0.0.80 index.d.ts for some reason, so use all.find() instead
+  const cocSpellChecker = coc.extensions.all.find(
+    (x) => x.id === cocSpellCheckerExtension
+  );
 
   if (cocSpellChecker) {
-    cocSpellChecker.extension.activate().then(ext => {
+    cocSpellChecker.activate().then((ext) => {
       if (enableDictionaries && enableDictionaries.length) {
-        enableDictionaries.forEach(lang => {
-          const dict = dicts[lang]
+        enableDictionaries.forEach((lang) => {
+          const dict = dicts[lang];
           if (dict) {
             if (dict.package) {
-              const packages = ([] as string[]).concat(dict.package)
-              packages.forEach(name => {
-                const p = require(name)
+              const packages = ([] as string[]).concat(dict.package);
+              packages.forEach((name) => {
+                const p = dict.newStyle ? require.resolve(name) : require(name);
                 if (p) {
-                  const path = p.getConfigLocation();
+                  const path = dict.newStyle ? p : p.getConfigLocation();
                   // We need to register the dictionary configuration with the Code Spell Checker Extension
                   ext && ext.registerConfig && ext.registerConfig(path);
                 }
-              })
+              });
             }
             if (dict.local) {
               // Push the disposable to the context's subscriptions so that the
               // client can be deactivated on extension deactivation
               context.subscriptions.push(
-                coc.commands.registerCommand(`cSpellExt_${lang}.enableCatalan`, () =>
-                  ext && ext.enableLocal && ext.enableLocal(true, dict.local)
-                ),
-                coc.commands.registerCommand(`cSpellExt_${lang}.disableCatalan`, () =>
-                  ext && ext.disableLocal && ext.disableLocal(true, dict.local)
+                coc.commands.registerCommand(
+                  `cSpellExt_${lang}.enable`,
+                  () =>
+                    ext && ext.enableLocal && ext.enableLocal(true, dict.local)
                 ),
                 coc.commands.registerCommand(
-                  `cSpellExt_${lang}.enableCatalanWorkspace`,
-                  () => ext && ext.enableLocal && ext.enableLocal(false, dict.local)
+                  `cSpellExt_${lang}.disable`,
+                  () =>
+                    ext &&
+                    ext.disableLocal &&
+                    ext.disableLocal(true, dict.local)
                 ),
                 coc.commands.registerCommand(
-                  `cSpellExt_${lang}.disableCatalanWorkspace`,
-                  () => ext && ext.disableLocal && ext.disableLocal(false, dict.local)
+                  `cSpellExt_${lang}.enableWorkspace`,
+                  () =>
+                    ext && ext.enableLocal && ext.enableLocal(false, dict.local)
+                ),
+                coc.commands.registerCommand(
+                  `cSpellExt_${lang}.disableWorkspace`,
+                  () =>
+                    ext &&
+                    ext.disableLocal &&
+                    ext.disableLocal(false, dict.local)
                 )
               );
             }
@@ -137,7 +157,9 @@ export function activate(context: coc.ExtensionContext) {
       }
     });
   } else {
-    coc.workspace.showMessage(`[coc-cspell-dicts]: require ${cocSpellCheckerExtension} extensions installed`)
+    coc.window.showMessage(
+      `[coc-cspell-dicts]: require ${cocSpellCheckerExtension} extensions installed`
+    );
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,13 @@
 {
   "compilerOptions": {
     "target": "es2015",
-    "lib": [
-      "es2015",
-      "esnext"
-    ],
+    "lib": ["es2015", "esnext"],
     "module": "commonjs",
     "declaration": false,
     "sourceMap": false,
     "outDir": "out",
     "strict": true,
+    "strictFunctionTypes": false,
     "moduleResolution": "node",
     "noImplicitAny": false,
     "esModuleInterop": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,87 +2,24 @@
 # yarn lockfile v1
 
 
-"@chemzqm/neovim@5.1.9":
-  version "5.1.9"
-  resolved "https://registry.yarnpkg.com/@chemzqm/neovim/-/neovim-5.1.9.tgz#9e1d07088e6224022e943a54cfd0f09faa3000da"
-  integrity sha512-lV60tnl2jcJZj3Hb+IDg6uz2zsjsB2hIGAiaW5a452SlVeLmuUoDsy2WaqRbFqcIHZKG5GTP3ttnOlB+ltHWhg==
-  dependencies:
-    msgpack-lite "^0.1.26"
+"@cspell/dict-nb-no@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/@cspell/dict-nb-no/-/dict-nb-no-1.0.3.tgz"
+  integrity sha512-cWqIkAtj5r+wbJrtbvrwh9TziiKJxKgL9fPpAo8tSORgtMuuKAXFIhMTG42Zw/4ytRoW304DtAEQRfQziky/sQ==
 
-"@types/node@^13.1.2":
-  version "13.1.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.1.2.tgz#fe94285bf5e0782e1a9e5a8c482b1c34465fa385"
-  integrity sha512-B8emQA1qeKerqd1dmIsQYnXi+mmAzTB7flExjmy5X1aVAKFNNNDubkavwR13kR6JnpeLp3aLoJhwn9trWPAyFQ==
+"@types/node@12.12.12":
+  version "12.12.12"
+  resolved "https://registry.npmjs.org/@types/node/-/node-12.12.12.tgz"
+  integrity sha512-MGuvYJrPU0HUwqF7LqvIj50RZUX23Z+m583KBygKYUZLlZ88n6w28XRNJRJgsHukLEnLz6w6SvxZoLgbr5wLqQ==
 
-await-semaphore@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/await-semaphore/-/await-semaphore-0.1.3.tgz#2b88018cc8c28e06167ae1cdff02504f1f9688d3"
-  integrity sha512-d1W2aNSYcz/sxYO4pMGX9vq65qOTu0P800epMud+6cYYX0QcT7zyqcxec3VWzpgvdXo57UWmVbZpLMjX2m1I7Q==
-
-balanced-match@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
-
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
-  dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
-
-bser@2.1.1, bser@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
-  integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
-  dependencies:
-    node-int64 "^0.4.0"
-
-chownr@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
-  integrity sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
-
-coc.nvim@^0.0.74:
-  version "0.0.74"
-  resolved "https://registry.yarnpkg.com/coc.nvim/-/coc.nvim-0.0.74.tgz#b3a6c3a47a8a1be2db578ac655e4396d4a696e0b"
-  integrity sha512-9U8l2lXjnOM7lgSSOLpLkdvUeh1UAxAKfeVLMZgXRdfuSZJF82GWX2326dbQR30s9icLpSLBsWbcC6KGxW/kRQ==
-  dependencies:
-    "@chemzqm/neovim" "5.1.9"
-    await-semaphore "^0.1.3"
-    bser "^2.1.0"
-    debounce "^1.2.0"
-    fast-diff "^1.2.0"
-    fb-watchman "^2.0.0"
-    follow-redirects "^1.9.0"
-    glob "^7.1.4"
-    isuri "^2.0.3"
-    jsonc-parser "^2.1.1"
-    log4js "^5.1.0"
-    minimatch "^3.0.4"
-    mkdirp "^0.5.1"
-    mv "^2.1.1"
-    rc "^1.2.8"
-    rimraf "^3.0.0"
-    semver "^6.3.0"
-    tar "^4.4.10"
-    tslib "^1.10.0"
-    tunnel "^0.0.6"
-    uuid "^3.3.3"
-    vscode-languageserver-protocol "3.15.0-next.6"
-    vscode-languageserver-types "3.15.0-next.2"
-    vscode-uri "^2.0.3"
-    which "^1.3.1"
-
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+coc.nvim@^0.0.80:
+  version "0.0.80"
+  resolved "https://registry.npmjs.org/coc.nvim/-/coc.nvim-0.0.80.tgz"
+  integrity sha512-/3vTcnofoAYMrdENrlQmADTzfXX4+PZ0fiM10a39UA37dTR2dpIGi9O469kcIksuunLjToqWG8S45AGx/9wV7g==
 
 configstore@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/configstore/-/configstore-5.0.0.tgz#37de662c7a49b5fe8dbcf8f6f5818d2d81ed852b"
+  resolved "https://registry.npmjs.org/configstore/-/configstore-5.0.0.tgz"
   integrity sha512-eE/hvMs7qw7DlcB5JPRnthmrITuHMmACUJAp89v6PT6iOqzoLS7HRWhBtuHMlhNHo2AhUSA/3Dh1bKNJHcublQ==
   dependencies:
     dot-prop "^5.1.0"
@@ -94,609 +31,215 @@ configstore@^5.0.0:
 
 crypto-random-string@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
+  resolved "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
 cspell-dict-ca@^1.0.9:
   version "1.0.13"
-  resolved "https://registry.yarnpkg.com/cspell-dict-ca/-/cspell-dict-ca-1.0.13.tgz#b04c8deab43444630969e20f0b456b448f373366"
+  resolved "https://registry.npmjs.org/cspell-dict-ca/-/cspell-dict-ca-1.0.13.tgz"
   integrity sha512-yIPhXOsF42cQmKQ9DOVPOPavsPhceuDZJvTROJashGk3gshRyWat3pVZx2LdFBCDWr7emlgmjp3A3NNqd3tEKg==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-cs-cz@^1.0.9:
   version "1.0.13"
-  resolved "https://registry.yarnpkg.com/cspell-dict-cs-cz/-/cspell-dict-cs-cz-1.0.13.tgz#f7854f7f1b770907495bd3ae875b14cbe527eeae"
+  resolved "https://registry.npmjs.org/cspell-dict-cs-cz/-/cspell-dict-cs-cz-1.0.13.tgz"
   integrity sha512-6e8i+XH80nPD3ywwuyA67udLo9apbbwoxeRzz8nXjQkriBvTEf6nUJxmvqHbWp0sw1TVj5AnT5hktFfQiI7EKA==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-da-dk@^1.0.16:
   version "1.0.19"
-  resolved "https://registry.yarnpkg.com/cspell-dict-da-dk/-/cspell-dict-da-dk-1.0.19.tgz#eea740e8d947912dd7e39e8a2b7fae713b1d4656"
+  resolved "https://registry.npmjs.org/cspell-dict-da-dk/-/cspell-dict-da-dk-1.0.19.tgz"
   integrity sha512-NBW6clEnRJLnQu+9bROqq1vCOa7hd44BqoO++2hsMgodFBB5UR2Zrh0h8KTmVBCWU+bL+zUoBzt8pvZIqLsJmQ==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-de-de@^1.1.16:
   version "1.1.21"
-  resolved "https://registry.yarnpkg.com/cspell-dict-de-de/-/cspell-dict-de-de-1.1.21.tgz#ba82a526faabb675aeca4271bab1aafa1845f982"
+  resolved "https://registry.npmjs.org/cspell-dict-de-de/-/cspell-dict-de-de-1.1.21.tgz"
   integrity sha512-qvFumH2iGOtNGxSkXzKIRSwvE7p012QXJi6pYB+fgLoyN4Es7kusDeUHz3ECEND06QdIxQkrFEC96OS88KuW8g==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-el@^1.0.4:
   version "1.0.7"
-  resolved "https://registry.yarnpkg.com/cspell-dict-el/-/cspell-dict-el-1.0.7.tgz#bb01a8934dce8b40eddad258abee6fe4bed24cd3"
+  resolved "https://registry.npmjs.org/cspell-dict-el/-/cspell-dict-el-1.0.7.tgz"
   integrity sha512-te3QGnTtX6xSVYQ1VAwYBpEm5c7IPxeEZ+JCqtMpKLl9dxpD3j+jgJIki8jZb5+Xco7eee0vj8qprY2aYJKykQ==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-es-es@^1.0.14:
   version "1.0.18"
-  resolved "https://registry.yarnpkg.com/cspell-dict-es-es/-/cspell-dict-es-es-1.0.18.tgz#2b8a05aea16d2880d4e20ad2454b7e21036acaf9"
+  resolved "https://registry.npmjs.org/cspell-dict-es-es/-/cspell-dict-es-es-1.0.18.tgz"
   integrity sha512-Q5dW9e2wpWIBQiMSjGYLyK5ZXFSrfPKde2TJTFS5mX9xA1UVV2sMC9bsPDxEWEK3WZkk/Ixrheeh8uHSvCiAvQ==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-fa-ir@^1.0.4:
   version "1.0.8"
-  resolved "https://registry.yarnpkg.com/cspell-dict-fa-ir/-/cspell-dict-fa-ir-1.0.8.tgz#19bf51381229c9cfb916f2006f897045d18cbfb6"
+  resolved "https://registry.npmjs.org/cspell-dict-fa-ir/-/cspell-dict-fa-ir-1.0.8.tgz"
   integrity sha512-9VUgPSS2Oo97/c330GxXaLvGsWxO8mWBnJDwNI6zzgcrcVTBD47fs+ZcR6cflQoW48QiyJsB/w5OrYK37A95nA==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-fr-fr@^1.2.7:
   version "1.2.11"
-  resolved "https://registry.yarnpkg.com/cspell-dict-fr-fr/-/cspell-dict-fr-fr-1.2.11.tgz#2be3f18031b7da12b290453b064526835b8ff456"
+  resolved "https://registry.npmjs.org/cspell-dict-fr-fr/-/cspell-dict-fr-fr-1.2.11.tgz"
   integrity sha512-78xiS14W62QWA0GOfEcGO/VrogBcHzTlLeeiUskP29chpWyGOGrg1H/cEqAC5fg06olyRFaH7+bAfNRcLGnhww==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-fr-reforme@^1.0.2:
   version "1.0.6"
-  resolved "https://registry.yarnpkg.com/cspell-dict-fr-reforme/-/cspell-dict-fr-reforme-1.0.6.tgz#c7e1356e86cd668ba0583253e176f4601ac3be7f"
+  resolved "https://registry.npmjs.org/cspell-dict-fr-reforme/-/cspell-dict-fr-reforme-1.0.6.tgz"
   integrity sha512-UJkN8gkp/1k1mwcz8b8z0bmr2QVrETEPKGgaMz/EWV8FWe6IrLuu5d7xYzJ9gKwrlxVDNdoPpei1kIGnL5lEFQ==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-it-it@^1.0.1:
   version "1.0.5"
-  resolved "https://registry.yarnpkg.com/cspell-dict-it-it/-/cspell-dict-it-it-1.0.5.tgz#c27c33e356aacbf9817675d5c4d90fa0ee72fac2"
+  resolved "https://registry.npmjs.org/cspell-dict-it-it/-/cspell-dict-it-it-1.0.5.tgz"
   integrity sha512-p0wJzqd6Fnt0+EAFrT8Oy7PG6wLEgWaBn5Woe3R6teAuTrSYHrTLN9P89JqujpgbxtnbcavX/0ratp7438uGNQ==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-medicalterms@^1.0.14:
   version "1.0.16"
-  resolved "https://registry.yarnpkg.com/cspell-dict-medicalterms/-/cspell-dict-medicalterms-1.0.16.tgz#fa9ebcd7368ca47b1e0cbd48d07e97892df0ab29"
+  resolved "https://registry.npmjs.org/cspell-dict-medicalterms/-/cspell-dict-medicalterms-1.0.16.tgz"
   integrity sha512-A88YA6JMJV34WXRPksGkn/LF29Fzb0TsEh7FLRyD8bQWmP2AM7BChEfNYdaWJEYQwTYZdjQbYZPf0xKFAWXz/Q==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-nl-nl@^1.0.19:
   version "1.0.23"
-  resolved "https://registry.yarnpkg.com/cspell-dict-nl-nl/-/cspell-dict-nl-nl-1.0.23.tgz#cbe07a6f951d9bcc37adbf51b399a247f4571535"
+  resolved "https://registry.npmjs.org/cspell-dict-nl-nl/-/cspell-dict-nl-nl-1.0.23.tgz"
   integrity sha512-sdt7Lh572AIgQvL3cAVK3Q4euxjsTlH3n37jc0pXg3bO8JIcYW7TXqAWCb4rOuUyaDDKpUNJM1v3fTL8+iXPNA==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-pl_pl@^1.0.15:
   version "1.0.19"
-  resolved "https://registry.yarnpkg.com/cspell-dict-pl_pl/-/cspell-dict-pl_pl-1.0.19.tgz#a5ad6d206206280b54f81b33dfba667f5b29ccb7"
+  resolved "https://registry.npmjs.org/cspell-dict-pl_pl/-/cspell-dict-pl_pl-1.0.19.tgz"
   integrity sha512-b9uqNPy0xEu6pGkGiWeYyogSwmIkhkgtgtBfXCZvONSqBuSXl4AsAwGCuDdQYR310vZGVkt7PoBat9UlZGYY0w==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-pt-br@^1.0.11:
   version "1.0.15"
-  resolved "https://registry.yarnpkg.com/cspell-dict-pt-br/-/cspell-dict-pt-br-1.0.15.tgz#d1e06270bf412e767048159ddeadea3dcde9509b"
+  resolved "https://registry.npmjs.org/cspell-dict-pt-br/-/cspell-dict-pt-br-1.0.15.tgz"
   integrity sha512-ygljBc9f0NTvxJepC+uStkYgvJg/jIpiZOdLcK2TktGU8iumLFOOxS2QFSuoxLIEtDPtLZ3poRqy1vegvheiAQ==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-pt-pt@^1.0.11:
   version "1.0.15"
-  resolved "https://registry.yarnpkg.com/cspell-dict-pt-pt/-/cspell-dict-pt-pt-1.0.15.tgz#a64e8961f0e0a7b2f8ade118a67b997bc67dc559"
+  resolved "https://registry.npmjs.org/cspell-dict-pt-pt/-/cspell-dict-pt-pt-1.0.15.tgz"
   integrity sha512-RvN5r3N2tBfBuo9bKquZ3+aPwMzCb6oPwLKVjdJGMV3LA9s2tNq99ATXf2OdzmSlI1lHCC1eqUmGjY0l+WTXqA==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-ru_ru@^1.1.12:
   version "1.1.15"
-  resolved "https://registry.yarnpkg.com/cspell-dict-ru_ru/-/cspell-dict-ru_ru-1.1.15.tgz#e45dd25d445bbe2a7f0c0f50e312fbbff14ebd92"
+  resolved "https://registry.npmjs.org/cspell-dict-ru_ru/-/cspell-dict-ru_ru-1.1.15.tgz"
   integrity sha512-wlHf7jWI5BB67AMAX4RM02pM9b3kFlbJlBpJZ4BZZnNPDSJC4egjrh9+9WsBk1mhJ7Dfa05RsI9j5vCAvLicUQ==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-russian@^1.1.13:
   version "1.1.17"
-  resolved "https://registry.yarnpkg.com/cspell-dict-russian/-/cspell-dict-russian-1.1.17.tgz#2706e11ee6d7879af6c7e990aed0e08563988cbb"
+  resolved "https://registry.npmjs.org/cspell-dict-russian/-/cspell-dict-russian-1.1.17.tgz"
   integrity sha512-v0SQOJhKFPtl16F1n2i6tx/pnfGMaZnidc6KeI57zH9m3ocSPrhVJpUo0WJM/hHUBO1CSiXFhUofmcphhdUApA==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-sv@^1.0.12:
   version "1.0.16"
-  resolved "https://registry.yarnpkg.com/cspell-dict-sv/-/cspell-dict-sv-1.0.16.tgz#38c846535bad79e6be70fcd8ddf269d423d1ec51"
+  resolved "https://registry.npmjs.org/cspell-dict-sv/-/cspell-dict-sv-1.0.16.tgz"
   integrity sha512-RNYoAPt9H3JiYWhGn6RnhjBi2ra+GsQfg4nz2tNI81Z+6m6ht2SzpOrDiwAYbq7uBy4d3Eb2d4xpq/T4uLlCnw==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-tr-tr@^1.0.6:
   version "1.0.10"
-  resolved "https://registry.yarnpkg.com/cspell-dict-tr-tr/-/cspell-dict-tr-tr-1.0.10.tgz#a4618f044248eef6b4bfbce498823c0d9ff581b7"
+  resolved "https://registry.npmjs.org/cspell-dict-tr-tr/-/cspell-dict-tr-tr-1.0.10.tgz"
   integrity sha512-6fCEly8FEY4TNXwVEqvVGMQZdkP442Xkei9ezrp9TrYKKPuXjY78N8+nhhIL0lYSnx7p+lxKdbL7/0saAhLsoQ==
   dependencies:
     configstore "^5.0.0"
 
 cspell-dict-uk-ua@^1.0.9:
   version "1.0.12"
-  resolved "https://registry.yarnpkg.com/cspell-dict-uk-ua/-/cspell-dict-uk-ua-1.0.12.tgz#98e2d7a0025d56a62511d33ecce964e1f50cbe3b"
+  resolved "https://registry.npmjs.org/cspell-dict-uk-ua/-/cspell-dict-uk-ua-1.0.12.tgz"
   integrity sha512-QLVayo7ZtjWmiwe6rlKpSxhWYhzzjyLwKU5rJUul4r08zdCJjwVfRqUUYegJf7RXXwDZO3iLs/ktmEPrSS+6jA==
   dependencies:
     configstore "^5.0.0"
 
-date-format@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/date-format/-/date-format-2.1.0.tgz#31d5b5ea211cf5fd764cd38baf9d033df7e125cf"
-  integrity sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==
-
-debounce@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
-  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
-
-debug@^3.0.0:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
-  dependencies:
-    ms "^2.1.1"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
-
 dot-prop@^5.1.0:
   version "5.2.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.2.0.tgz#c34ecc29556dc45f1f4c22697b6f4904e0cc4fcb"
+  resolved "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz"
   integrity sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==
   dependencies:
     is-obj "^2.0.0"
 
-event-lite@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/event-lite/-/event-lite-0.1.2.tgz#838a3e0fdddef8cc90f128006c8e55a4e4e4c11b"
-  integrity sha512-HnSYx1BsJ87/p6swwzv+2v6B4X+uxUteoDfRxsAb1S1BePzQqOLevVmkdA15GHJVd9A9Ok6wygUR18Hu0YeV9g==
-
-fast-diff@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
-  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
-
-fb-watchman@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.1.tgz#fc84fb39d2709cf3ff6d743706157bb5708a8a85"
-  integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
-  dependencies:
-    bser "2.1.1"
-
-flatted@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
-  integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
-
-follow-redirects@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.9.0.tgz#8d5bcdc65b7108fe1508649c79c12d732dcedb4f"
-  integrity sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==
-  dependencies:
-    debug "^3.0.0"
-
-fs-extra@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
-  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
-
-fs.realpath@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
-  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
-
-glob@^6.0.1:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
-  integrity sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.3, glob@^7.1.4:
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+graceful-fs@^4.1.2:
   version "4.2.3"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
+  resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
-
-ieee754@^1.1.8:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
-  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
 imurmurhash@^0.1.4:
   version "0.1.4"
-  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
-
-inflight@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
-  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
-  dependencies:
-    once "^1.3.0"
-    wrappy "1"
-
-inherits@2:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
-  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-ini@~1.3.0:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
-
-int64-buffer@^0.1.9:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-0.1.10.tgz#277b228a87d95ad777d07c13832022406a473423"
-  integrity sha1-J3siiofZWtd30HwTgyAiQGpHNCM=
 
 is-obj@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
+  resolved "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz"
   integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
 
 is-typedarray@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+  resolved "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
-
-isarray@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
-
-isexe@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
-  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
-
-isuri@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/isuri/-/isuri-2.0.3.tgz#3437121db2fe65af0ba080b7e1a8636f632cca91"
-  integrity sha1-NDcSHbL+Za8LoIC34ahjb2MsypE=
-  dependencies:
-    rfc-3986 "1.0.1"
-
-jsonc-parser@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.2.0.tgz#f206f87f9d49d644b7502052c04e82dd6392e9ef"
-  integrity sha512-4fLQxW1j/5fWj6p78vAlAafoCKtuBm6ghv+Ij5W2DrDx0qE+ZdEl2c6Ko1mgJNF5ftX1iEWQQ4Ap7+3GlhjkOA==
-
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
-log4js@^5.1.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/log4js/-/log4js-5.3.0.tgz#7e43fa49f516c2d11c71ae28eddffd508eef2ba8"
-  integrity sha512-PZHXaXJKMKEscvQxSnTjM4UosQalSDlNpMw63eCKW+/DiAFKIZPW1jGyIPXZDjiEYFusMfiI7zzvnxeGozUcAw==
-  dependencies:
-    date-format "^2.1.0"
-    debug "^4.1.1"
-    flatted "^2.0.1"
-    rfdc "^1.1.4"
-    streamroller "^2.2.2"
 
 make-dir@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.0.tgz#1b5f39f6b9270ed33f9f054c5c0f84304989f801"
+  resolved "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz"
   integrity sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==
   dependencies:
     semver "^6.0.0"
 
-"minimatch@2 || 3", minimatch@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
-  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
-
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
-
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
-  dependencies:
-    minimist "0.0.8"
-
-ms@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
-  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
-msgpack-lite@^0.1.26:
-  version "0.1.26"
-  resolved "https://registry.yarnpkg.com/msgpack-lite/-/msgpack-lite-0.1.26.tgz#dd3c50b26f059f25e7edee3644418358e2a9ad89"
-  integrity sha1-3TxQsm8FnyXn7e42REGDWOKprYk=
-  dependencies:
-    event-lite "^0.1.1"
-    ieee754 "^1.1.8"
-    int64-buffer "^0.1.9"
-    isarray "^1.0.0"
-
-mv@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
-  integrity sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=
-  dependencies:
-    mkdirp "~0.5.1"
-    ncp "~2.0.0"
-    rimraf "~2.4.0"
-
-ncp@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
-  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
-
-node-int64@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
-  integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
-
-once@^1.3.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
-  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
-  dependencies:
-    wrappy "1"
-
-path-is-absolute@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
-
-rc@^1.2.8:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
-rfc-3986@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/rfc-3986/-/rfc-3986-1.0.1.tgz#eeeb88342fadbe8027c0f36ada921a13e6f96206"
-  integrity sha1-7uuINC+tvoAnwPNq2pIaE+b5YgY=
-
-rfdc@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.1.4.tgz#ba72cc1367a0ccd9cf81a870b3b58bd3ad07f8c2"
-  integrity sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==
-
-rimraf@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.0.tgz#614176d4b3010b75e5c390eb0ee96f6dc0cebb9b"
-  integrity sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@~2.4.0:
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
-  integrity sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=
-  dependencies:
-    glob "^6.0.1"
-
-safe-buffer@^5.1.2:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
-  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
-
-semver@^6.0.0, semver@^6.3.0:
+semver@^6.0.0:
   version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 signal-exit@^3.0.2:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
-
-streamroller@^2.2.2:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-2.2.3.tgz#b95c9fad44e2e89005d242141486b3b4962c2d28"
-  integrity sha512-AegmvQsscTRhHVO46PhCDerjIpxi7E+d2GxgUDu+nzw/HuLnUdxHWr6WQ+mVn/4iJgMKKFFdiUwFcFRDvcjCtw==
-  dependencies:
-    date-format "^2.1.0"
-    debug "^4.1.1"
-    fs-extra "^8.1.0"
-
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
-tar@^4.4.10:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
-
-tslib@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
-  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
-
-tunnel@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
-  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
-  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  resolved "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz"
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
 
+typescript@^4.5.4:
+  version "4.6.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz"
+  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
+
 unique-string@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"
+  resolved "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz"
   integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
   dependencies:
     crypto-random-string "^2.0.0"
 
-universalify@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
-  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
-
-uuid@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
-  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
-
-vscode-jsonrpc@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
-  integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
-
-vscode-jsonrpc@^4.1.0-next.2:
-  version "4.1.0-next.3"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.1.0-next.3.tgz#05fe742959a2726020d4d0bfbc3d3c97873c7fde"
-  integrity sha512-Z6oxBiMks2+UADV1QHXVooSakjyhI+eHTnXzDyVvVMmegvSfkXk2w6mPEdSkaNHFBdtWW7n20H1yw2nA3A17mg==
-
-vscode-languageserver-protocol@3.15.0-next.6:
-  version "3.15.0-next.6"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.6.tgz#a8aeb7e7dd65da8216b386db59494cdfd3215d92"
-  integrity sha512-/yDpYlWyNs26mM23mT73xmOFsh1iRfgZfBdHmfAxwDKwpQKLoOSqVidtYfxlK/pD3IEKGcAVnT4WXTsguxxAMQ==
-  dependencies:
-    vscode-jsonrpc "^4.1.0-next.2"
-    vscode-languageserver-types "^3.15.0-next.2"
-
-vscode-languageserver-protocol@^3.14.1:
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz#b8aab6afae2849c84a8983d39a1cf742417afe2f"
-  integrity sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==
-  dependencies:
-    vscode-jsonrpc "^4.0.0"
-    vscode-languageserver-types "3.14.0"
-
-vscode-languageserver-types@3.14.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
-  integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
-
-vscode-languageserver-types@3.15.0-next.2:
-  version "3.15.0-next.2"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.2.tgz#a0601332cdaafac21931f497bb080cfb8d73f254"
-  integrity sha512-2JkrMWWUi2rlVLSo9OFR2PIGUzdiowEM8NgNYiwLKnXTjpwpjjIrJbNNxDik7Rv4oo9KtikcFQZKXbrKilL/MQ==
-
-vscode-languageserver-types@^3.15.0-next.2:
-  version "3.15.0-next.9"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.9.tgz#957a9d1d5998a02edf62298fb7e37d9efcc6c157"
-  integrity sha512-Rl/8qJ6932nrHCdPn+9y0x08uLVQaSLRG+U4JzhyKpWU4eJbVaDRoAcz1Llj7CErJGbPr6kdBvShPy5fRfR+Uw==
-
-vscode-uri@^2.0.3:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.1.tgz#5aa1803391b6ebdd17d047f51365cf62c38f6e90"
-  integrity sha512-eY9jmGoEnVf8VE8xr5znSah7Qt1P/xsCdErz+g8HYZtJ7bZqKH5E3d+6oVNm1AC/c6IHUDokbmVXKOi4qPAC9A==
-
-which@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
-  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
-  dependencies:
-    isexe "^2.0.0"
-
-wrappy@1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
-
 write-file-atomic@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.1.tgz#558328352e673b5bb192cf86500d60b230667d4b"
+  resolved "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz"
   integrity sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==
   dependencies:
     imurmurhash "^0.1.4"
@@ -706,10 +249,5 @@ write-file-atomic@^3.0.0:
 
 xdg-basedir@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
+  resolved "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
-
-yallist@^3.0.0, yallist@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
-  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==


### PR DESCRIPTION
+ Bumped coc.nvim to 0.0.80, I couldn't make it build with older
  coc.nvim, because of some typescript errors in coc.nvim library.

+ Bumped @types/node to the same version as coc.nvim 0.0.80 uses

+ Added typescript as dev dependency, so you dont need it installed
  globally

+ If the dict is 'newStyle' use require.resolve() instead of
  require().getConfigLocation()

+ coc.nvim 0.0.80 doesnt export extensions.getExtension function to index.d.ts, (even
  though it exists in the sourcecode) so use extensions.all.find()
  instead.

+ Added norwegian (nb) dictionary, I set the local to the same as what
  is defined here https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/nb_NO/cspell-ext.json#L28

+ Removed the catalan word inside the registerCommand's, cause im pretty
  sure that was not supposed to be there

Also, my prettier extension went a bit mayhem here :/

Also its an option to update all the dictionaries to "newStyle", then it wont need special logic.  